### PR TITLE
feat: Introduce new initialization methods for local streams and update stage management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 jsconfig.json
 
 .env
+/docs
 
 # Xcode
 #

--- a/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoRealtimeIvsBroadcastModule.kt
+++ b/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoRealtimeIvsBroadcastModule.kt
@@ -46,8 +46,14 @@ class ExpoRealtimeIvsBroadcastModule : Module(), IVSStageManagerDelegate {
             )
         }
 
-        AsyncFunction("initialize") { audioConfig: Map<String, Any>?, videoConfig: Map<String, Any>? ->
+        AsyncFunction("initializeStage") { audioConfig: Map<String, Any>?, videoConfig: Map<String, Any>? ->
+            // TODO: Add audioConfig and videoConfig
             IVSStageManager.instance?.initializeStage(audioConfig = null, videoConfig = null)
+        }
+
+        AsyncFunction("initializeLocalStreams") { audioConfig: Map<String, Any>?, videoConfig: Map<String, Any>? ->
+            // TODO: Add audioConfig and videoConfig
+            IVSStageManager.instance?.initializeLocalStreams()
         }
 
         AsyncFunction("joinStage") { token: String, options: Map<String, Any>? ->

--- a/ios/ExpoRealtimeIvsBroadcastModule.swift
+++ b/ios/ExpoRealtimeIvsBroadcastModule.swift
@@ -26,12 +26,14 @@ public class ExpoRealtimeIvsBroadcastModule: Module, IVSStageManagerDelegate {
 
     // --- Methods Exposed to JS ---
 
-    AsyncFunction("initialize") { (audioConfigMap: [String: Any]?, videoConfigMap: [String: Any]?) -> Void in
-      // TODO: Parse audioConfigMap and videoConfigMap into IVSLocalStageStreamAudioConfiguration and IVSLocalStageStreamVideoConfiguration
+    AsyncFunction("initializeStage") { (audioConfigMap: [String: Any]?, videoConfigMap: [String: Any]?) -> Void in
       // For now, using nil, which will use default configurations in IVSStageManager
-      // Example: let audioConfig = parseAudioConfig(audioConfigMap)
-      //          let videoConfig = parseVideoConfig(videoConfigMap)
       self.ivsStageManager?.initializeStage(audioConfig: nil, videoConfig: nil)
+    }
+
+    AsyncFunction("initializeLocalStreams") { (audioConfigMap: [String: Any]?, videoConfigMap: [String: Any]?) -> Void in
+        // For now, using nil, which will use default configurations in IVSStageManager
+        self.ivsStageManager?.initializeLocalStreams(audioConfig: nil, videoConfig: nil)
     }
 
     AsyncFunction("joinStage") { (token: String, options: [String: Any]?) in

--- a/src/ExpoRealtimeIvsBroadcast.types.ts
+++ b/src/ExpoRealtimeIvsBroadcast.types.ts
@@ -93,7 +93,7 @@ export type ExpoIVSStagePreviewViewProps = {
 // Props for the new remote stream view
 export type ExpoIVSRemoteStreamViewProps = {
   style?: StyleProp<ViewStyle>;
-  participantId: string;
-  deviceUrn: string;
+  participantId?: string;
+  deviceUrn?: string;
   scaleMode?: 'fit' | 'fill';
 };

--- a/src/ExpoRealtimeIvsBroadcastModule.ts
+++ b/src/ExpoRealtimeIvsBroadcastModule.ts
@@ -5,7 +5,8 @@ import { LocalAudioConfig, LocalVideoConfig, PermissionStatusMap, ExpoRealtimeIv
 // By defining `addListener` and `removeListeners` explicitly, we get strong type-checking
 // for our event names and payloads, resolving the 'never' type error.
 export type ExpoRealtimeIvsBroadcastModuleType = {
-  initialize(audioConfig?: LocalAudioConfig, videoConfig?: LocalVideoConfig): Promise<void>;
+  initializeStage(audioConfig?: LocalAudioConfig, videoConfig?: LocalVideoConfig): Promise<void>;
+  initializeLocalStreams(audioConfig?: LocalAudioConfig, videoConfig?: LocalVideoConfig): Promise<void>;
   joinStage(token: string, options?: { targetParticipantId?: string }): Promise<void>;
   leaveStage(): Promise<void>;
   setStreamsPublished(published: boolean): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,12 @@ export { ExpoIVSRemoteStreamView } from './ExpoIVSRemoteStreamView';
 export { useStageParticipants } from './useStageParticipants';
 
 // --- Native Module Methods ---
-export async function initialize(audioConfig?: LocalAudioConfig, videoConfig?: LocalVideoConfig): Promise<void> {
-  return await ExpoRealtimeIvsBroadcastModule.initialize(audioConfig, videoConfig);
+export async function initializeStage(audioConfig?: LocalAudioConfig, videoConfig?: LocalVideoConfig): Promise<void> {
+  return await ExpoRealtimeIvsBroadcastModule.initializeStage(audioConfig, videoConfig);
+}
+
+export async function initializeLocalStreams(audioConfig?: LocalAudioConfig, videoConfig?: LocalVideoConfig): Promise<void> {
+  return await ExpoRealtimeIvsBroadcastModule.initializeLocalStreams(audioConfig, videoConfig);
 }
 
 export async function joinStage(token: string, options?: { targetParticipantId?: string }): Promise<void> {


### PR DESCRIPTION
- Renamed existing `initialize` method to `initializeStage` for clarity and added `initializeLocalStreams` method to handle local stream setup.
- Updated `IVSStageManager` to manage local streams and device discovery more effectively.
- Enhanced the example app to support role selection and local stream initialization, improving user experience.
- Adjusted type definitions to reflect new method signatures and optional properties for participant streams.