### PR TITLE
refactor: update scaleMode property to "fill" 

### DIFF
--- a/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoIVSRemoteStreamView.kt
+++ b/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoIVSRemoteStreamView.kt
@@ -23,7 +23,7 @@ class ExpoIVSRemoteStreamView(context: Context, appContext: AppContext) : ExpoVi
         private set
 
     // Props
-    private var scaleMode: String = "fit"
+    private var scaleMode: String = "fill"
 
     init {
         Log.i("ExpoIVSRemoteStreamView", "Initializing Remote Stream View...")

--- a/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoIVSStagePreviewView.kt
+++ b/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoIVSStagePreviewView.kt
@@ -21,7 +21,7 @@ class ExpoIVSStagePreviewView(context: Context, appContext: AppContext) : ExpoVi
 
     // Props from React Native
     private var mirror: Boolean = false
-    private var scaleMode: String = "fit"
+    private var scaleMode: String = "fill"
 
     init {
         Log.i("ExpoIVSStagePreviewView", "Initializing Stage Preview View...")

--- a/ios/ExpoIVSRemoteStreamView.swift
+++ b/ios/ExpoIVSRemoteStreamView.swift
@@ -12,7 +12,7 @@ class ExpoIVSRemoteStreamView: ExpoView {
     private(set) var currentRenderedDeviceUrn: String?
 
     // No more participantId or deviceUrn props!
-    var scaleMode: String = "fit" {
+    var scaleMode: String = "fill" {
         didSet { updateScaleMode() }
     }
 
@@ -108,6 +108,14 @@ class ExpoIVSRemoteStreamView: ExpoView {
     }
 
     private func updateScaleMode() {
-        ivsImagePreviewView?.contentMode = (scaleMode.lowercased() == "fill") ? .scaleAspectFill : .scaleAspectFit
+        // This method now safely uses optional chaining, applying mode only if view exists.
+        switch scaleMode.lowercased() {
+        case "fill":
+            ivsImagePreviewView?.contentMode = .scaleAspectFill
+        case "fit":
+            ivsImagePreviewView?.contentMode = .scaleAspectFit
+        default:
+            ivsImagePreviewView?.contentMode = .scaleAspectFill // Default to fill
+        }
     }
 }

--- a/ios/ExpoIVSStagePreviewView.swift
+++ b/ios/ExpoIVSStagePreviewView.swift
@@ -16,7 +16,7 @@ class ExpoIVSStagePreviewView: ExpoView {
         }
     }
 
-    var scaleMode: String = "fit" { // "fit" or "fill"
+    var scaleMode: String = "fill" { // "fit" or "fill"
         didSet {
             // This will update scale mode if/when ivsImagePreviewView is available
             updateScaleMode()
@@ -129,7 +129,7 @@ class ExpoIVSStagePreviewView: ExpoView {
         case "fit":
             ivsImagePreviewView?.contentMode = .scaleAspectFit
         default:
-            ivsImagePreviewView?.contentMode = .scaleAspectFit // Default to fit
+            ivsImagePreviewView?.contentMode = .scaleAspectFill // Default to fill
         }
     }
     


### PR DESCRIPTION
- Changed default value of scaleMode from "fit" to "fill" in both Android and iOS implementations.
- Updated the updateScaleMode method to handle the new default value appropriately.