### PR TITLE
feat: fix Android display issues and iOS camera swap (v0.1.4)

### DIFF
--- a/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoIVSRemoteStreamView.kt
+++ b/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoIVSRemoteStreamView.kt
@@ -2,8 +2,9 @@ package expo.modules.realtimeivsbroadcast
 
 import android.content.Context
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
-import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.RequiresApi
 import com.amazonaws.ivs.broadcast.BroadcastConfiguration.AspectMode
@@ -17,6 +18,12 @@ import expo.modules.kotlin.views.ExpoView
 class ExpoIVSRemoteStreamView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
     private var ivsImagePreviewView: ImagePreviewView? = null
     private var stageManager: IVSStageManager? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+    
+    // Retry configuration
+    private var retryCount = 0
+    private val maxRetries = 10
+    private val retryDelayMs = 200L
 
     // The only state this view knows is what it's currently showing
     var currentRenderedDeviceUrn: String? = null
@@ -27,33 +34,60 @@ class ExpoIVSRemoteStreamView(context: Context, appContext: AppContext) : ExpoVi
 
     init {
         Log.i("ExpoIVSRemoteStreamView", "Initializing Remote Stream View...")
-        resolveStageManager()
+        resolveStageManagerWithRetry()
     }
     
-    private fun resolveStageManager() {
-        Log.d("ExpoIVSRemoteStreamView", "Attempting to resolve StageManager singleton...")
-        this.stageManager = IVSStageManager.instance
-
-        if (this.stageManager == null) {
-            Log.e("ExpoIVSRemoteStreamView", "IVSStageManager singleton instance is null.")
+    private fun resolveStageManagerWithRetry() {
+        Log.d("ExpoIVSRemoteStreamView", "Attempting to resolve StageManager singleton (attempt ${retryCount + 1})...")
+        
+        val manager = IVSStageManager.instance
+        
+        if (manager == null) {
+            if (retryCount < maxRetries) {
+                retryCount++
+                Log.w("ExpoIVSRemoteStreamView", "IVSStageManager not ready, retrying in ${retryDelayMs}ms...")
+                mainHandler.postDelayed({ resolveStageManagerWithRetry() }, retryDelayMs)
+            } else {
+                Log.e("ExpoIVSRemoteStreamView", "IVSStageManager singleton is null after $maxRetries attempts.")
+            }
             return
         }
+        
+        this.stageManager = manager
         Log.d("ExpoIVSRemoteStreamView", "StageManager instance assigned. Registering view...")
-
-        // Announce its existence to the manager so it can be used as a canvas
-        this.stageManager?.registerRemoteView(this)
+        manager.registerRemoteView(this)
     }
 
     // This is the command the manager will issue to this view
     fun renderStream(device: Device) {
+        // Ensure we're on the main thread for UI operations
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            mainHandler.post { renderStream(device) }
+            return
+        }
+        
         if (device.descriptor.urn == this.currentRenderedDeviceUrn) {
+            Log.d("ExpoIVSRemoteStreamView", "Already rendering device: ${device.descriptor.urn}")
             return // Already rendering this device
         }
 
         cleanupStreamView()
 
         try {
-            val newPreview = (device as ImageDevice).previewView
+            Log.i("ExpoIVSRemoteStreamView", "Attempting to render stream for device: ${device.descriptor.urn}")
+            
+            val imageDevice = device as? ImageDevice
+            if (imageDevice == null) {
+                Log.e("ExpoIVSRemoteStreamView", "Device is not an ImageDevice: ${device.descriptor.type}")
+                return
+            }
+            
+            val newPreview = imageDevice.previewView
+            if (newPreview == null) {
+                Log.e("ExpoIVSRemoteStreamView", "Failed to get preview view from ImageDevice")
+                return
+            }
+            
             newPreview.layoutParams = FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
                 FrameLayout.LayoutParams.MATCH_PARENT
@@ -64,18 +98,24 @@ class ExpoIVSRemoteStreamView(context: Context, appContext: AppContext) : ExpoVi
             addView(newPreview)
             
             applyProps()
+            Log.i("ExpoIVSRemoteStreamView", "✅ Successfully rendering stream for device: ${device.descriptor.urn}")
         } catch (e: Exception) {
-            // Handle exceptions, e.g., if the device is not an ImageDevice
+            Log.e("ExpoIVSRemoteStreamView", "❌ Failed to render stream: ${e.message}", e)
             cleanupStreamView()
         }
     }
     
     fun clearStream() {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            mainHandler.post { clearStream() }
+            return
+        }
         cleanupStreamView()
     }
 
     private fun cleanupStreamView() {
         if (ivsImagePreviewView != null) {
+            Log.d("ExpoIVSRemoteStreamView", "Cleaning up stream view")
             removeView(ivsImagePreviewView)
             ivsImagePreviewView = null
         }
@@ -94,18 +134,29 @@ class ExpoIVSRemoteStreamView(context: Context, appContext: AppContext) : ExpoVi
             else -> AspectMode.FIT
         }
         try {
-            // Use reflection to set the aspect mode, as there is no public method.
             val method = ivsImagePreviewView?.javaClass?.getMethod("setPreviewAspectMode", AspectMode::class.java)
             method?.invoke(ivsImagePreviewView, aspectMode)
         } catch (e: Exception) {
-            // If the method doesn't exist or fails, the default scale mode will be used.
+            Log.w("ExpoIVSRemoteStreamView", "Could not set aspect mode: ${e.message}")
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        Log.d("ExpoIVSRemoteStreamView", "View attached to window")
+        // Re-register if we lost the manager reference
+        if (stageManager == null) {
+            retryCount = 0
+            resolveStageManagerWithRetry()
         }
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        // Clean up when the view is removed from the UI
+        Log.d("ExpoIVSRemoteStreamView", "View detached from window")
+        // Remove any pending retries
+        mainHandler.removeCallbacksAndMessages(null)
         stageManager?.unregisterRemoteView(this)
         cleanupStreamView()
     }
-} 
+}

--- a/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoRealtimeIvsBroadcastModule.kt
+++ b/android/src/main/java/expo/modules/realtimeivsbroadcast/ExpoRealtimeIvsBroadcastModule.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
+import android.util.Log
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.exception.Exceptions
@@ -25,9 +26,13 @@ class ExpoRealtimeIvsBroadcastModule : Module(), IVSStageManagerDelegate {
         )
 
         OnCreate {
+            Log.i("ExpoRealtimeIvsBroadcast", "Module OnCreate - Initializing IVSStageManager...")
             if (IVSStageManager.instance == null) {
                 val reactContext = appContext.reactContext ?: throw Exceptions.ReactContextLost()
                 IVSStageManager(reactContext)
+                Log.i("ExpoRealtimeIvsBroadcast", "IVSStageManager instance created")
+            } else {
+                Log.i("ExpoRealtimeIvsBroadcast", "IVSStageManager instance already exists")
             }
             IVSStageManager.instance?.delegate = this@ExpoRealtimeIvsBroadcastModule
         }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AmazonIVSBroadcast/Stages (1.30.0)
+  - AmazonIVSBroadcast/Stages (1.36.0)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - EXConstants (17.1.6):
@@ -64,8 +64,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoRealtimeIvsBroadcast (0.1.0):
-    - AmazonIVSBroadcast/Stages (~> 1.30.0)
+  - ExpoRealtimeIvsBroadcast (0.1.3):
+    - AmazonIVSBroadcast/Stages (~> 1.36.0)
     - ExpoModulesCore
   - fast_float (6.1.4)
   - FBLazyVector (0.79.3)
@@ -1970,7 +1970,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AmazonIVSBroadcast: 8549ba4be7bed7e78f67292f264f7e9492b42d18
+  AmazonIVSBroadcast: b76ac7519bd77e4815f9e36eb08a70f4ec11488c
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EXConstants: 9f310f44bfedba09087042756802040e464323c0
@@ -1980,7 +1980,7 @@ SPEC CHECKSUMS:
   ExpoFont: abbb91a911eb961652c2b0a22eef801860425ed6
   ExpoKeepAwake: bf0811570c8da182bfb879169437d4de298376e7
   ExpoModulesCore: d431ffe83c8673d02cb38425594a5f5480fd3061
-  ExpoRealtimeIvsBroadcast: 56ca89246b4842e2caafaab0a2364da9853ddd82
+  ExpoRealtimeIvsBroadcast: 160fce14b7187f0688485d56d037e4e0cdf74285
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: a62a7a5760929b6265e27bc01ab7598dde93ebd3
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd

--- a/example/ios/exporealtimeivsbroadcastexample.xcodeproj/project.pbxproj
+++ b/example/ios/exporealtimeivsbroadcastexample.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = expo.modules.realtimeivsbroadcast.example;
-				PRODUCT_NAME = "exporealtimeivsbroadcastexample";
+				PRODUCT_NAME = exporealtimeivsbroadcastexample;
 				SWIFT_OBJC_BRIDGING_HEADER = "exporealtimeivsbroadcastexample/exporealtimeivsbroadcastexample-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -385,7 +385,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = expo.modules.realtimeivsbroadcast.example;
-				PRODUCT_NAME = "exporealtimeivsbroadcastexample";
+				PRODUCT_NAME = exporealtimeivsbroadcastexample;
 				SWIFT_OBJC_BRIDGING_HEADER = "exporealtimeivsbroadcastexample/exporealtimeivsbroadcastexample-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/ExpoIVSStagePreviewView.swift
+++ b/ios/ExpoIVSStagePreviewView.swift
@@ -1,39 +1,41 @@
 import ExpoModulesCore
 import AmazonIVSBroadcast
 import UIKit
+import AVFoundation
 
 class ExpoIVSStagePreviewView: ExpoView {
     private var ivsImagePreviewView: IVSImagePreviewView?
-    private weak var stageManager: IVSStageManager? // Hold a weak reference
-    private var currentPreviewDeviceUrn: String? 
+    private var customPreviewLayer: AVCaptureVideoPreviewLayer?
+    private weak var stageManager: IVSStageManager?
+    private var currentPreviewDeviceUrn: String?
+    private var isUsingCustomPreview: Bool = false
 
     // Props from React Native
     var mirror: Bool = false {
         didSet {
-            // This will apply mirroring if/when ivsImagePreviewView is available
-            print("DEBUG: mirroring" + String(describing: mirror))
-            ivsImagePreviewView?.setMirrored(mirror)
+            print("DEBUG: mirroring " + String(describing: mirror))
+            if isUsingCustomPreview {
+                // For custom preview, we mirror by transforming the layer
+                updateCustomPreviewMirror()
+            } else {
+                ivsImagePreviewView?.setMirrored(mirror)
+            }
         }
     }
 
-    var scaleMode: String = "fill" { // "fit" or "fill"
+    var scaleMode: String = "fill" {
         didSet {
-            // This will update scale mode if/when ivsImagePreviewView is available
             updateScaleMode()
         }
     }
 
     required init(appContext: AppContext? = nil) {
         super.init(appContext: appContext)
-        // setupView() // Removed
         resolveStageManagerAndStream()
     }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        // This initializer might be used by UIKit, ensure setup is called.
-        // However, ExpoView typically uses the appContext initializer.
-        // setupView() // Removed
         resolveStageManagerAndStream()
     }
     
@@ -41,17 +43,14 @@ class ExpoIVSStagePreviewView: ExpoView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // private func setupView() { ... } // Entire method removed
-
     private func resolveStageManagerAndStream() {
         guard let moduleRegistry = appContext?.moduleRegistry else {
             print("ExpoIVSStagePreviewView: Could not find moduleRegistry in app context.")
             return
         }
-        // Try to get the module by its registered name from the ModuleRegistry
         guard let untypedModule = moduleRegistry.get(moduleWithName: "ExpoRealtimeIvsBroadcast"),
               let module = untypedModule as? ExpoRealtimeIvsBroadcastModule else {
-            print("ExpoIVSStagePreviewView: Could not find or cast ExpoRealtimeIvsBroadcastModule from module registry using get(moduleWithName:).")
+            print("ExpoIVSStagePreviewView: Could not find or cast ExpoRealtimeIvsBroadcastModule.")
             return
         }
         self.stageManager = module.ivsStageManager
@@ -59,11 +58,62 @@ class ExpoIVSStagePreviewView: ExpoView {
     }
     
     func attachStream() {
+        guard let manager = self.stageManager else {
+            print("ExpoIVSStagePreviewView: StageManager not available.")
+            return
+        }
+        
+        // Check if we should use custom preview or native IVS preview
+        if manager.isUsingCustomCameraCapture() {
+            print("ExpoIVSStagePreviewView: Using CUSTOM camera preview layer")
+            attachCustomPreview()
+        } else {
+            print("ExpoIVSStagePreviewView: Using NATIVE IVS preview")
+            attachNativePreview()
+        }
+    }
+    
+    private func attachCustomPreview() {
+        // Remove any existing previews
+        removeAllPreviews()
+        
+        guard let previewLayer = stageManager?.getCustomCameraPreviewLayer() else {
+            print("ExpoIVSStagePreviewView: Custom preview layer not available yet.")
+            return
+        }
+        
+        isUsingCustomPreview = true
+        customPreviewLayer = previewLayer
+        
+        // Configure the preview layer
+        previewLayer.frame = bounds
+        previewLayer.videoGravity = scaleMode.lowercased() == "fill" ? .resizeAspectFill : .resizeAspect
+        
+        // Ensure the connection is enabled
+        if let connection = previewLayer.connection {
+            connection.isEnabled = true
+            if connection.isVideoOrientationSupported {
+                connection.videoOrientation = .portrait
+            }
+            print("ExpoIVSStagePreviewView: Preview layer connection enabled, orientation set")
+        } else {
+            print("ExpoIVSStagePreviewView: ⚠️ Preview layer has no connection yet")
+        }
+        
+        // Add to view
+        layer.addSublayer(previewLayer)
+        
+        // Apply mirror if needed
+        updateCustomPreviewMirror()
+        
+        print("ExpoIVSStagePreviewView: ✅ Custom preview layer attached, frame: \(bounds)")
+    }
+    
+    private func attachNativePreview() {
         guard let stream = self.stageManager?.getCameraStream() else {
             print("ExpoIVSStagePreviewView: Camera stream not yet available from StageManager.")
-            // If stream isn't available, and we have an old preview, remove it.
             if let oldPreview = self.ivsImagePreviewView {
-                print("ExpoIVSStagePreviewView: Camera stream unavailable, removing old preview.")
+                print("ExpoIVSStagePreviewView: Removing old preview.")
                 oldPreview.removeFromSuperview()
                 self.ivsImagePreviewView = nil
                 self.currentPreviewDeviceUrn = nil
@@ -73,27 +123,22 @@ class ExpoIVSStagePreviewView: ExpoView {
 
         let newDeviceUrn = stream.device.descriptor().urn
 
-        // If preview view exists and is for the *same* device, do nothing.
+        // If preview view exists and is for the same device, do nothing
         if let existingPreview = self.ivsImagePreviewView, self.currentPreviewDeviceUrn == newDeviceUrn {
-            print("ExpoIVSStagePreviewView: Preview for the correct device (\(newDeviceUrn)) already exists.")
+            print("ExpoIVSStagePreviewView: Preview for the correct device already exists.")
             return
         }
 
-        // If preview exists but for a *different* device, or if no preview exists, create/recreate it.
-        if let oldPreview = self.ivsImagePreviewView {
-            print("ExpoIVSStagePreviewView: Stream device changed (or preview needs refresh). Removing old preview for \((self.currentPreviewDeviceUrn ?? "nil")) before creating new one for \(newDeviceUrn).")
-            oldPreview.removeFromSuperview()
-            self.ivsImagePreviewView = nil
-            self.currentPreviewDeviceUrn = nil // Clear old URN
-        }
+        // Remove old preview if exists
+        removeAllPreviews()
 
         guard let imageDevice = stream.device as? IVSImageDevice else {
-            print("ExpoIVSStagePreviewView: Stream's device ('\(newDeviceUrn)') does not conform to IVSImageDevice.")
+            print("ExpoIVSStagePreviewView: Stream's device does not conform to IVSImageDevice.")
             return
         }
 
         do {
-            print("ExpoIVSStagePreviewView: Attempting to create IVSImagePreviewView from device: \(newDeviceUrn)")
+            print("ExpoIVSStagePreviewView: Creating IVSImagePreviewView for device: \(newDeviceUrn)")
             let newPreview = try imageDevice.previewView()
             newPreview.translatesAutoresizingMaskIntoConstraints = false
             
@@ -105,46 +150,88 @@ class ExpoIVSStagePreviewView: ExpoView {
                 newPreview.trailingAnchor.constraint(equalTo: trailingAnchor)
             ])
             
+            isUsingCustomPreview = false
             self.ivsImagePreviewView = newPreview
-            self.currentPreviewDeviceUrn = newDeviceUrn // Store the URN of the new device
+            self.currentPreviewDeviceUrn = newDeviceUrn
             
             self.ivsImagePreviewView?.setMirrored(self.mirror)
             updateScaleMode()
 
-            print("ExpoIVSStagePreviewView: Successfully created and configured IVSImagePreviewView for \(newDeviceUrn).")
-            // No need to call setStream on IVSImagePreviewView as it's intrinsically linked to the device it was created from.
+            print("ExpoIVSStagePreviewView: ✅ Native IVS preview attached for \(newDeviceUrn)")
 
         } catch {
-            print("ExpoIVSStagePreviewView: Failed to create IVSImagePreviewView from device \(newDeviceUrn): \(error)")
-            self.ivsImagePreviewView = nil // Ensure it's nil on failure
+            print("ExpoIVSStagePreviewView: Failed to create IVSImagePreviewView: \(error)")
+            self.ivsImagePreviewView = nil
             self.currentPreviewDeviceUrn = nil
+        }
+    }
+    
+    private func removeAllPreviews() {
+        // Remove native preview
+        if let oldPreview = self.ivsImagePreviewView {
+            oldPreview.removeFromSuperview()
+            self.ivsImagePreviewView = nil
+            self.currentPreviewDeviceUrn = nil
+        }
+        
+        // Remove custom preview layer
+        if let oldLayer = self.customPreviewLayer {
+            oldLayer.removeFromSuperlayer()
+            self.customPreviewLayer = nil
+        }
+    }
+    
+    private func updateCustomPreviewMirror() {
+        guard let previewLayer = customPreviewLayer else { return }
+        
+        if mirror {
+            // Mirror horizontally
+            previewLayer.transform = CATransform3DMakeScale(-1, 1, 1)
+        } else {
+            previewLayer.transform = CATransform3DIdentity
         }
     }
 
     private func updateScaleMode() {
-        // This method now safely uses optional chaining, applying mode only if view exists.
-        switch scaleMode.lowercased() {
-        case "fill":
-            ivsImagePreviewView?.contentMode = .scaleAspectFill
-        case "fit":
-            ivsImagePreviewView?.contentMode = .scaleAspectFit
-        default:
-            ivsImagePreviewView?.contentMode = .scaleAspectFill // Default to fill
+        if isUsingCustomPreview {
+            customPreviewLayer?.videoGravity = scaleMode.lowercased() == "fill" ? .resizeAspectFill : .resizeAspect
+        } else {
+            switch scaleMode.lowercased() {
+            case "fill":
+                ivsImagePreviewView?.contentMode = .scaleAspectFill
+            case "fit":
+                ivsImagePreviewView?.contentMode = .scaleAspectFit
+            default:
+                ivsImagePreviewView?.contentMode = .scaleAspectFill
+            }
         }
     }
     
-    // Call this if the stream becomes available after the view is initialized
-    // or if you suspect the stream needs to be re-attached.
     func refreshStream() {
         print("ExpoIVSStagePreviewView: refreshStream() called.")
-        // If ivsImagePreviewView is nil, attachStream will try to create it.
-        // If it exists, it will just re-set the stream.
         attachStream()
     }
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        // Auto Layout should handle subview resizing.
-        // If specific manual frame adjustments were needed, they'd go here.
+        // Update custom preview layer frame when view resizes
+        if isUsingCustomPreview, let previewLayer = customPreviewLayer {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            previewLayer.frame = bounds
+            CATransaction.commit()
+            print("ExpoIVSStagePreviewView: layoutSubviews - updated preview frame to \(bounds)")
+        }
     }
-} 
+    
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        // When the view is added to a window, try to attach stream if not already done
+        if window != nil && customPreviewLayer == nil && ivsImagePreviewView == nil {
+            print("ExpoIVSStagePreviewView: didMoveToWindow - attempting to attach stream")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.attachStream()
+            }
+        }
+    }
+}

--- a/ios/ExpoRealtimeIvsBroadcast.podspec
+++ b/ios/ExpoRealtimeIvsBroadcast.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'AmazonIVSBroadcast/Stages', '~> 1.30.0'
+  s.dependency 'AmazonIVSBroadcast/Stages', '~> 1.36.0'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/ios/ExpoRealtimeIvsBroadcastModule.swift
+++ b/ios/ExpoRealtimeIvsBroadcastModule.swift
@@ -85,7 +85,7 @@ public class ExpoRealtimeIvsBroadcastModule: Module, IVSStageManagerDelegate {
       }
 
       Prop("scaleMode") { (view: ExpoIVSStagePreviewView, scaleMode: String) in // "fit" or "fill"
-        print("DEBUG: Setting stage preview scaleMode to \(scaleMode)")
+        print("DEBUG: Setting stage preview sc›aleMode to \(scaleMode)")
         view.scaleMode = scaleMode
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-realtime-ivs-broadcast",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "An Expo module for real-time broadcasting using Amazon IVS.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## 🚀 Release v0.1.4

### Android Fixes
- ✅ Add retry logic for IVSStageManager initialization (race condition fix)
- ✅ Add main thread dispatch for UI operations
- ✅ Add proper exception logging instead of silent swallowing
- ✅ Add onAttachedToWindow/onDetachedFromWindow handlers
- ✅ Fix camera swap by notifying preview views to refresh
- ✅ Improve stream assignment logging for debugging

### iOS Fixes
- ✅ Add custom camera capture workaround for IVS Stages SDK limitation
- ✅ Back camera now works via AVCaptureSession -> IVSCustomImageSource
- ✅ Camera swap works on both front and back cameras
- ✅ Add camera discovery fallback chain (wide-angle -> dual/triple -> telephoto/ultra-wide -> any)
- ✅ Update IVS SDK from 1.30 to 1.36

### Breaking Changes
- None

### Testing
- [x] Android - Preview displays correctly
- [x] Android - Camera swap works
- [x] iOS - Preview displays correctly  
- [x] iOS - Camera swap works (front ↔ back)

### npm
Already published as `expo-realtime-ivs-broadcast@0.1.4`