### PR TITLE
Release v0.2.1: Fix iOS PiP pre-warming failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This module provides React Native components and a comprehensive API to integrat
 
 | Library Version | Expo SDK | React Native | React   | Notes |
 |-----------------|----------|--------------|---------|-------|
-| 0.2.0           | 54       | 0.81.x       | 19.1.x  | **Added Picture-in-Picture support** |
+| 0.2.1           | 54       | 0.81.x       | 19.1.x  | **Fixed iOS PiP pre-warming reliability** |
+| 0.2.0           | 54       | 0.81.x       | 19.1.x  | Added Picture-in-Picture support |
 | 0.1.7           | 54       | 0.81.x       | 19.1.x  | |
 | 0.1.4           | 53       | 0.79.x       | 19.0.x  | |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-realtime-ivs-broadcast",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An Expo module for real-time broadcasting using Amazon IVS.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Summary

- Fix PiP pre-warming failure when source view is not in window hierarchy
- Add window hierarchy validation and retry logic with exponential backoff
- Improve pre-warming with more frames (15 frames over 0.5s) and better timing
- Defer PiP registration until view is properly in window
- Add diagnostic logging for troubleshooting PiP issues

## Changes

### `IVSPictureInPictureController.swift`
- Added `pendingSourceView` property to track deferred setup
- `setupWithSourceView()` now validates source view is in window before setup
- Added `retrySetupWithSourceView()` with exponential backoff (up to 10 attempts)
- Added `aggressivePreWarm()` for initial setup (15 frames at 30fps)
- Improved `preWarmWithPlaceholder()` with multiple retry attempts and diagnostic logging

### `ExpoIVSStagePreviewView.swift`
- `registerForPiP()` now only registers when view is in a window
- `didMoveToWindow()` properly handles PiP registration lifecycle

## Test plan

- [x] Test PiP functionality on iOS device
- [x] Verify PiP starts successfully after pre-warming
- [x] Confirm no "PiP is not possible" errors during normal usage
