### PR TITLE
fix(ios): comprehensive PiP fix for remote streams

### DIFF
--- a/ios/ExpoIVSRemoteStreamView.swift
+++ b/ios/ExpoIVSRemoteStreamView.swift
@@ -103,9 +103,17 @@ class ExpoIVSRemoteStreamView: ExpoView {
             print("✅ [REMOTE VIEW] Manager commanded me to render URN: \(deviceUrn)")
             
             // Notify the stage manager that a stream started rendering (for PiP)
-            // Use a small delay to ensure the view is fully set up
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-                self?.stageManager?.notifyRemoteStreamRendered()
+            // Use a longer delay to ensure the view hierarchy is fully set up
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                guard let self = self else { return }
+                print("✅ [REMOTE VIEW] Notifying PiP system - view in window: \(self.window != nil), isRenderingVideo: \(self.isRenderingVideo)")
+                self.stageManager?.notifyRemoteStreamRendered()
+            }
+            
+            // Also notify immediately for faster setup if view is already ready
+            if self.window != nil {
+                print("✅ [REMOTE VIEW] View already in window, notifying PiP immediately")
+                self.stageManager?.notifyRemoteStreamRendered()
             }
         } catch {
             print("❌ [REMOTE VIEW] Failed to create preview for URN \(deviceUrn): \(error)")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-realtime-ivs-broadcast",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "An Expo module for real-time broadcasting using Amazon IVS.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Summary

This PR addresses the PiP not working for viewers (remote streams) by adding debug logging and multiple fallback mechanisms to ensure `setupWithSourceView()` is always called.

## Root Cause

The key issue was that `setupWithSourceView()` was never being called because the view matching was failing due to URN timing issues. Without this call, `AVPictureInPictureController` is never created.

## Changes

| File | Function | Change |
|------|----------|--------|
| `ios/IVSStageManager.swift` | `updatePiPSourceIfNeeded()` | Add debug logging for views/URNs, add "any view" last resort fallback |
| `ios/IVSStageManager.swift` | `attachToDevice()` | Add success log, restructure fallbacks with else-if chain, add "any view" last resort |
| `ios/ExpoIVSRemoteStreamView.swift` | `renderStream()` | Increase notification delay to 0.3s, add immediate notification if view ready |
| `package.json` | - | Bump version to 0.2.3 |

## Expected Logs After Fix

```
🖼️ [PiP] Enabled with Video Call API: autoEnter=true, source=remote
✅ [REMOTE VIEW] View already in window, notifying PiP immediately
🖼️ [PiP] Registered remote views: 1
🖼️ [PiP]   View 0: URN=webrtc_source:..., isRendering=true
🖼️ [PiP] Found new remote video stream: webrtc_source:...
🖼️ [PiP] Found matching remote view for source
🖼️ [PiP] Attaching frame callback to device: webrtc_source:...
🖼️ [PiP] Set up with matching remote view container
```

## Test Plan

- [ ] Open a live stream as a viewer
- [ ] Press home button → PiP should auto-enter
- [ ] Click minimize button in stream header → should minimize to PiP
