### PR TITLE
fix(ios): track valid source view state for PiP re-setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-realtime-ivs-broadcast",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "An Expo module for real-time broadcasting using Amazon IVS.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Problem

From the logs, the issue was clear:

```
🖼️ [PiP] Registered remote views: 0          ← No views yet!
🖼️ [PiP] Set up with device preview view     ← Falls back to internal IVS view
...
🧠 [MANAGER] A remote view has registered    ← View registers LATER
🖼️ [PiP] Frame #0: 720x1280                  ← Frames are captured but...
```

The `currentPiPSourceDeviceUrn` was already set when the remote view registered, so `updatePiPSourceIfNeeded()` skipped re-setup because the URN matched.

## Solution

Added `pipHasValidSourceView` flag to track whether we have a **visible** source view:

1. When using `device.previewView()` fallback → mark as `NOT valid`
2. When using an actual remote view → mark as `VALID`
3. In `updatePiPSourceIfNeeded()` → force re-setup if flag is `false`
4. Prioritize finding remote views BEFORE falling back to `device.previewView()`

## Expected Logs After Fix

```
🖼️ [PiP] Set up with device preview view (NOT VALID - will re-setup when remote view available)
...
🧠 [MANAGER] A remote view has registered
...
🖼️ [PiP] Setting up PiP for remote video stream (need valid source view): webrtc_source:...
🖼️ [PiP]   pipHasValidSourceView: false
🖼️ [PiP] Found matching remote view for source
🖼️ [PiP] Set up with provided source view (VALID)
```

## Test Plan

- [ ] Open a live stream as a viewer
- [ ] Verify logs show "need valid source view" re-setup
- [ ] Press home button → PiP should work