### PR TITLE
fix(ios): use ViewFrameCapture for remote streams PiP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-realtime-ivs-broadcast",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "An Expo module for real-time broadcasting using Amazon IVS.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Problem

PiP was showing "LIVE - Broadcasting in progress" placeholder instead of actual video for viewers.

## Root Cause

`IVSImageDevice.setOnFrameCallbackQueue()` is designed for **local camera** frame capture:
- For local streams, this callback receives pixel buffers directly from the camera
- For **remote streams**, frames come through WebRTC and are rendered to an `IVSImagePreviewView`
- The device callback doesn't properly capture remote stream frames

## Solution

Use `ViewFrameCapture` (`pipController.startViewCapture(from: targetView)`) for remote streams:
- Uses `CADisplayLink` + `drawHierarchy()` to capture frames directly from the visible UIView
- This works for any UIView including IVS preview views
- Keep device frame callback for local/broadcaster streams where it works correctly

## Changes

```swift
if _pipOptions.sourceView == .remote {
    // Use view capture for remote streams
    pipController.startViewCapture(from: targetView)
} else {
    // Use device frame callback for local streams
    device.setOnFrameCallbackQueue(...)
}
```

## Test Plan

- [ ] Open a live stream as a viewer
- [ ] PiP should show actual video (not "LIVE" placeholder)
- [ ] Broadcaster PiP should still work correctly
