### PR TITLE
fix(ios): revert ViewFrameCapture, use Video Call API for all PiP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-realtime-ivs-broadcast",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "An Expo module for real-time broadcasting using Amazon IVS.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Summary

Reverts the ViewFrameCapture approach from v0.2.5 which caused flickering (screen recording style). Returns to the proper Video Call API approach that was working in v0.2.4.

## PiP Architecture

Both **LOCAL (broadcaster)** and **REMOTE (viewer)** PiP use the same Video Call API approach:

| Step | Description |
|------|-------------|
| 1. `setupWithSourceView()` | Sets the visible view showing video |
| 2. `enqueueFrame()` | Feeds frames via `IVSImageDevice` callback |

### Difference between Local and Remote

| Mode | Source View | Frame Source |
|------|-------------|--------------|
| **LOCAL** (Broadcaster) | `ExpoIVSStagePreviewView` | `cameraStream` device (IVSCamera or IVSCustomImageSource) |
| **REMOTE** (Viewer) | `ExpoIVSRemoteStreamView` | Remote participant's video `IVSImageDevice` |

## Changes

- Reverted ViewFrameCapture approach (caused flickering)
- Added documentation comments to clarify local vs remote PiP separation
- Both modes now use the proper Video Call API with device frame callbacks

## Why ViewFrameCapture Was Wrong

- `ViewFrameCapture` uses `CADisplayLink` + `drawHierarchy()` = screen recording style
- This causes flickering and is not as efficient as the Video Call API
- The Video Call API with `IVSImageDevice.setOnFrameCallbackQueue()` receives frames directly from the IVS SDK pipeline
